### PR TITLE
Improve cython performance

### DIFF
--- a/examples/extensions/cython/mandel.pyx
+++ b/examples/extensions/cython/mandel.pyx
@@ -32,7 +32,7 @@ def mandelbrot(int N,
                 if m[i, j] == 0:
                     z[i, j] = z[i, j] * z[i, j] + c[i, j]
 
-                    if np.abs(z[i,j]) > 2:
+                    if abs(z[i,j]) > 2:
                         m[i, j] = n
 
     return m


### PR DESCRIPTION
`np.abs(z[i, j])` calls into Python unnecessarily, and using `abs(z[i, j])` instead gives much better results. On my machine with Cython 0.29.37, this runs the test case in 80ms. This is significantly better than numba and f2py, which are tied for second place at ~120ms.

Curiously, I get worse performance (~140ms) with Cython 3.0.5.

I used `cythonize -a mandel.pyx` to find the slowdown. Before:
![mandel-cython-before](https://github.com/sbu-python-class/python-science/assets/522590/08b5e530-3267-4528-884a-d02f43b18bfb)
and after:
![mandel-cython-after](https://github.com/sbu-python-class/python-science/assets/522590/e9d310f4-ca7e-4548-be62-8da2210b21f3)